### PR TITLE
RuntimeError fix

### DIFF
--- a/sphinxcontrib/jinjadomain.py
+++ b/sphinxcontrib/jinjadomain.py
@@ -106,13 +106,13 @@ class JinjaDomain(Domain):
 
     def clear_doc(self, docname):
         for typ, routes in self.routes.iteritems():
-            for path, info in routes.items():
+            for path, info in list(routes.items()):
                 if info[0] == docname:
                     del routes[path]
 
     def get_objects(self):
         for method, routes in self.routes.iteritems():
-            for path, info in routes.iteritems():
+            for path, info in list(routes.iteritems()):
                 anchor = jinja_resource_anchor(method, path)
                 yield (path, path, method, info[0], anchor, 1)
 


### PR DESCRIPTION
(With #4 applied) I encountered a `RuntimeError` exception while buiding documentation.

This PR fixes the issue.

```
# Platform:         linux; (Linux-6.9.1-arch1-1-x86_64-with-glibc2.39)
# Sphinx version:   7.3.7
# Python version:   3.12.3 (CPython)
# Docutils version: 0.21.2
# Jinja2 version:   3.1.4
# Pygments version: 2.18.0

# Last messages:
#   Écriture...
#
#   construction [html] : cibles périmées pour les fichiers sources 1
#   mise à jour de l'environnement :
#   0 ajouté(s), 1 modifié(s), 0 supprimé(s)
#
#   lecture des sources... [100%]
#   references/templates
#
#   sphinx-sitemap: No pages generated for sitemap.xml

# Loaded extensions:
#   sphinx.ext.mathjax (7.3.7)
#   alabaster (0.7.16)
#   sphinxcontrib.applehelp (1.0.8)
#   sphinxcontrib.devhelp (1.0.6)
#   sphinxcontrib.htmlhelp (2.0.5)
#   sphinxcontrib.serializinghtml (1.1.10)
#   sphinxcontrib.qthelp (1.0.7)
#   sphinx.ext.autodoc.preserve_defaults (7.3.7)
#   sphinx.ext.autodoc.type_comment (7.3.7)
#   sphinx.ext.autodoc.typehints (7.3.7)
#   sphinx.ext.autodoc (7.3.7)
#   sphinx.ext.autosectionlabel (7.3.7)
#   sphinx.ext.doctest (7.3.7)
#   sphinx.ext.graphviz (7.3.7)
#   sphinx.ext.intersphinx (7.3.7)
#   sphinx.ext.todo (7.3.7)
#   sphinx.ext.viewcode (7.3.7)
#   sphinx_click (unknown version)
#   sphinx_design (0.5.0)
#   sphinx_issues (4.1.0)
#   sphinx_sitemap (2.6.0)
#   sphinxcontrib.autodoc_pydantic (2.2.0)
#   sphinxcontrib.images (7.3.7)
#   sphinxcontrib.jinjadomain (unknown version)
#   sphinxcontrib.autojinja.jinja (unknown version)
#   shibuya (2024.5.15)

# Traceback:
Traceback (most recent call last):
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/cmd/build.py", line 337, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/application.py", line 351, in build
    self.builder.build_update()
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 293, in build_update
    self.build(to_build,
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 313, in build
    updated_docnames = set(self.read())
                           ^^^^^^^^^^^
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 419, in read
    self._read_serial(docnames)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 439, in _read_serial
    self.env.clear_doc(docname)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/environment/__init__.py", line 374, in clear_doc
    domain.clear_doc(docname)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinxcontrib/jinjadomain.py", line 120, in clear_doc
    for path, info in routes.items():
RuntimeError: dictionary changed size during iteration
```