### PR TITLE
dict_items sorting exception fix

### DIFF
--- a/sphinxcontrib/jinjadomain.py
+++ b/sphinxcontrib/jinjadomain.py
@@ -76,7 +76,7 @@ class JinjaIndex(Index):
                 path, 0, info[0],
                 jinja_resource_anchor(method, path), '', '', info[1]
             ])
-        content = content.items()
+        content = list(content.items())
         content.sort(key=lambda (k, v): k)
         return (content, True)
 


### PR DESCRIPTION
(With #4 applied) I encountered an exception related to the fact that `dict_items` objects cannot be sorted. This PR fixes the issue.

```
# Platform:         linux; (Linux-6.9.1-arch1-1-x86_64-with-glibc2.39)
# Sphinx version:   7.3.7
# Python version:   3.12.3 (CPython)
# Docutils version: 0.21.2
# Jinja2 version:   3.1.4
# Pygments version: 2.18.0

# Last messages:
#
#   Recherche des fichiers périmés...
#   aucun résultat trouvé
#   Environnement de sérialisation...
#   fait
#   vérification de la cohérence...
#   fait
#   documents en préparation...
#   échoué
#   sphinx-sitemap: No pages generated for sitemap.xml

# Loaded extensions:
#   sphinx.ext.mathjax (7.3.7)
#   alabaster (0.7.16)
#   sphinxcontrib.applehelp (1.0.8)
#   sphinxcontrib.devhelp (1.0.6)
#   sphinxcontrib.htmlhelp (2.0.5)
#   sphinxcontrib.serializinghtml (1.1.10)
#   sphinxcontrib.qthelp (1.0.7)
#   sphinx.ext.autodoc.preserve_defaults (7.3.7)
#   sphinx.ext.autodoc.type_comment (7.3.7)
#   sphinx.ext.autodoc.typehints (7.3.7)
#   sphinx.ext.autodoc (7.3.7)
#   sphinx.ext.autosectionlabel (7.3.7)
#   sphinx.ext.doctest (7.3.7)
#   sphinx.ext.graphviz (7.3.7)
#   sphinx.ext.intersphinx (7.3.7)
#   sphinx.ext.todo (7.3.7)
#   sphinx.ext.viewcode (7.3.7)
#   sphinx_click (unknown version)
#   sphinx_design (0.5.0)
#   sphinx_issues (4.1.0)
#   sphinx_sitemap (2.6.0)
#   sphinxcontrib.autodoc_pydantic (2.2.0)
#   sphinxcontrib.images (7.3.7)
#   sphinxcontrib.jinjadomain (unknown version)
#   shibuya (2024.5.15)

# Traceback:
Traceback (most recent call last):
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/cmd/build.py", line 337, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/application.py", line 351, in build
    self.builder.build_update()
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 293, in build_update
    self.build(to_build,
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 362, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/__init__.py", line 559, in write
    self.prepare_writing(docnames)
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinx/builders/html/__init__.py", line 477, in prepare_writing
    content, collapse = indexcls(domain).generate()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eloi/.cache/pypoetry/virtualenvs/canaille-9pOPObZA-py3.12/lib/python3.12/site-packages/sphinxcontrib/jinjadomain.py", line 96, in generate
    content.sort(key=lambda k: k[0])
    ^^^^^^^^^^^^
AttributeError: 'dict_items' object has no attribute 'sort'
```